### PR TITLE
Fix formatting of authentication passwords in mediamtx.yml

### DIFF
--- a/client/data/mediamtx.yml
+++ b/client/data/mediamtx.yml
@@ -13,17 +13,17 @@ udpMaxPayloadSize: 1472
 authMethod: internal
 authInternalUsers:
   - user: any
-    pass:
+    pass: ""
     ips: []
     permissions:
       - action: publish
-        path:
+        path: ""
       - action: read
-        path:
+        path: ""
       - action: playback
-        path:
+        path: ""
   - user: any
-    pass:
+    pass: ""
     ips: ['127.0.0.1', '::1']
     permissions:
       - action: api


### PR DESCRIPTION
This pull request makes a minor update to the `client/data/mediamtx.yml` configuration file. It sets empty strings as default values for the `pass` and `path` fields for users, likely to clarify that these fields are intentionally left blank rather than undefined.

- Configuration update:
  * Set `pass` and `path` fields to empty strings for user entries in `mediamtx.yml` to explicitly indicate blank values.